### PR TITLE
Update cron schedule to run every hour

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,4 +3,4 @@ main = "src/index.js"
 compatibility_date = "2024-06-14"
 
 [triggers]
-crons = ["0 12 * * *"]  # Run daily at noon UTC
+crons = ["0 * * * *"]  # Run every hour at the top of the hour


### PR DESCRIPTION
## Summary
- Changed cron schedule from daily (noon UTC) to hourly execution
- This provides more frequent API keepalive calls to Chainstack

## Test plan
- [ ] Verify GitHub Actions deployment succeeds
- [ ] Confirm worker runs every hour as scheduled

🤖 Generated with [Claude Code](https://claude.ai/code)